### PR TITLE
test(crud-naruto): adicionado testes nas classes de Service, Controller, GlobalExceptionHandler e Jwt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
     <artifactId>jjwt-jackson</artifactId>
     <version>0.11.5</version>
 </dependency>
+<dependency>
+    <groupId>org.springframework.security</groupId>
+    <artifactId>spring-security-test</artifactId>
+    <scope>test</scope>
+</dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>

--- a/src/main/java/com/sylviavitoria/naruto/config/OpenApiConfig.java
+++ b/src/main/java/com/sylviavitoria/naruto/config/OpenApiConfig.java
@@ -3,7 +3,6 @@ package com.sylviavitoria.naruto.config;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,8 @@ springdoc.swagger-ui.operationsSorter=method
 springdoc.swagger-ui.tagsSorter=alpha
 
 # JWT Configuration
+spring.security.user.name=test
+spring.security.user.password=test
 jwt.secret=404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970
 jwt.expiration=86400000
 

--- a/src/test/java/com/sylviavitoria/naruto/Service/PersonagemServiceTest.java
+++ b/src/test/java/com/sylviavitoria/naruto/Service/PersonagemServiceTest.java
@@ -1,0 +1,484 @@
+package com.sylviavitoria.naruto.Service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.sylviavitoria.naruto.dto.PersonagemDTO;
+import com.sylviavitoria.naruto.model.NinjaDeGenjutsu;
+import com.sylviavitoria.naruto.model.NinjaDeNinjutsu;
+import com.sylviavitoria.naruto.model.NinjaDeTaijutsu;
+import com.sylviavitoria.naruto.model.Personagem;
+import com.sylviavitoria.naruto.repository.PersonagemRepository;
+import com.sylviavitoria.naruto.service.PersonagemService;
+
+@ExtendWith(MockitoExtension.class)
+public class PersonagemServiceTest {
+
+    @Mock
+    private PersonagemRepository repository;
+
+    @InjectMocks
+    private PersonagemService service;
+
+    private NinjaDeTaijutsu personagemTaijutsu;
+    private NinjaDeNinjutsu personagemNinjutsu;
+    private NinjaDeGenjutsu personagemGenjutsu;
+    private PageImpl<Personagem> pagePersonagens;
+    private Pageable pageable;
+
+    @BeforeEach
+    void setUp() {
+        personagemTaijutsu = new NinjaDeTaijutsu();
+        personagemTaijutsu.setId(1L);
+        personagemTaijutsu.setNome("Rock Lee");
+        personagemTaijutsu.setIdade(16);
+        personagemTaijutsu.setAldeia("Aldeia da Folha");
+        personagemTaijutsu.setChakra(100);
+        personagemTaijutsu.setJutsus(Arrays.asList("Dynamic Entry", "Leaf Hurricane"));
+
+        personagemNinjutsu = new NinjaDeNinjutsu();
+        personagemNinjutsu.setId(2L);
+        personagemNinjutsu.setNome("Naruto Uzumaki");
+        personagemNinjutsu.setIdade(17);
+        personagemNinjutsu.setAldeia("Aldeia da Folha");
+        personagemNinjutsu.setChakra(500);
+        personagemNinjutsu.setJutsus(Arrays.asList("Rasengan", "Kage Bunshin no Jutsu"));
+
+        personagemGenjutsu = new NinjaDeGenjutsu();
+        personagemGenjutsu.setId(3L);
+        personagemGenjutsu.setNome("Itachi Uchiha");
+        personagemGenjutsu.setIdade(21);
+        personagemGenjutsu.setAldeia("Aldeia da Folha");
+        personagemGenjutsu.setChakra(300);
+        personagemGenjutsu.setJutsus(Arrays.asList("Tsukuyomi", "Amaterasu"));
+
+        List<Personagem> personagens = Arrays.asList(personagemTaijutsu, personagemNinjutsu, personagemGenjutsu);
+        pagePersonagens = new PageImpl<>(personagens);
+        
+        pageable = PageRequest.of(0, 10);
+    }
+
+    @Test
+    @DisplayName("Deve listar todos os personagens com paginação")
+    void deveListarTodosComPaginacao() {
+        when(repository.findAll(pageable)).thenReturn(pagePersonagens);
+
+        Page<Personagem> resultado = service.listarTodos(pageable);
+
+        assertNotNull(resultado);
+        assertEquals(3, resultado.getTotalElements());
+        assertEquals(pagePersonagens, resultado);
+        verify(repository).findAll(pageable);
+    }
+
+    @Test
+    @DisplayName("Deve buscar personagem por ID com sucesso")
+    void deveBuscarPorIdComSucesso() {
+        Long idDePersonagem = 1L;
+        when(repository.findById(idDePersonagem)).thenReturn(Optional.of(personagemTaijutsu));
+
+        Personagem resultado = service.buscarPorId(1L);
+
+        assertNotNull(resultado);
+        assertEquals(personagemTaijutsu.getId(), resultado.getId());
+        assertEquals(personagemTaijutsu.getNome(), resultado.getNome());
+        verify(repository).findById(idDePersonagem);
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção quando buscar personagem inexistente")
+    void deveLancarExcecaoQuandoBuscarPersonagemInexistente() {
+        Long idDePersonagemInexistente = 99L;
+        when(repository.findById(idDePersonagemInexistente)).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            service.buscarPorId(idDePersonagemInexistente);
+        });
+        
+        assertEquals("Personagem nao encontrado", exception.getMessage());
+        verify(repository).findById(idDePersonagemInexistente);
+    }
+
+    @Test
+    @DisplayName("Deve salvar personagem com sucesso")
+    void deveSalvarPersonagemComSucesso() {
+        when(repository.save(personagemTaijutsu)).thenReturn(personagemTaijutsu);
+
+        Personagem resultado = service.salvar(personagemTaijutsu);
+
+        assertNotNull(resultado);
+        assertEquals(personagemTaijutsu.getId(), resultado.getId());
+        assertEquals(personagemTaijutsu.getNome(), resultado.getNome());
+        verify(repository).save(personagemTaijutsu);
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção ao tentar salvar personagem com chakra negativo")
+    void deveLancarExcecaoAoTentarSalvarPersonagemComChakraNegativo() {
+        int chakraNegativo = -10;
+        personagemTaijutsu.setChakra(chakraNegativo);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.salvar(personagemTaijutsu);
+        });
+        
+        assertEquals("Chakra nao pode ser negativo", exception.getMessage());
+        verify(repository, never()).save(any(Personagem.class));
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção ao tentar salvar personagem sem nome")
+    void deveLancarExcecaoAoTentarSalvarPersonagemSemNome() {
+        personagemTaijutsu.setNome("");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.salvar(personagemTaijutsu);
+        });
+        
+        assertEquals("Nome é obrigatorio", exception.getMessage());
+        verify(repository, never()).save(any(Personagem.class));
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção ao tentar salvar personagem com nome nulo")
+    void deveLancarExcecaoAoTentarSalvarPersonagemComNomeNulo() {
+        personagemTaijutsu.setNome(null);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.salvar(personagemTaijutsu);
+        });
+        
+        assertEquals("Nome é obrigatorio", exception.getMessage());
+        verify(repository, never()).save(any(Personagem.class));
+    }
+
+    @Test
+    @DisplayName("Deve deletar personagem com sucesso")
+    void deveDeletarPersonagemComSucesso() {
+        Long idDeletar = 1L;
+        when(repository.existsById(idDeletar)).thenReturn(true);
+        doNothing().when(repository).deleteById(idDeletar);
+
+        service.deletar(idDeletar);
+
+        verify(repository).existsById(idDeletar);
+        verify(repository).deleteById(idDeletar);
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção ao tentar deletar personagem inexistente")
+    void deveLancarExcecaoAoTentarDeletarPersonagemInexistente() {
+        Long idDeletarInexistente = 99L;
+        when(repository.existsById(idDeletarInexistente)).thenReturn(false);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.deletar(idDeletarInexistente);
+        });
+        
+        assertEquals("Personagem com ID 99 nao existe", exception.getMessage());
+        verify(repository).existsById(idDeletarInexistente);
+        verify(repository, never()).deleteById(anyLong());
+    }
+    
+    @Test
+    @DisplayName("Deve atualizar personagem existente com sucesso")
+    void deveAtualizarPersonagemExistenteComSucesso() {
+        Long idPersonagem = 1L;
+        int idadePersonagem = 17;
+        personagemTaijutsu.setNome("Rock Lee");
+        personagemTaijutsu.setIdade(idadePersonagem);
+        
+        when(repository.findById(idPersonagem)).thenReturn(Optional.of(personagemTaijutsu));
+        when(repository.save(any(Personagem.class))).thenReturn(personagemTaijutsu);
+
+        Personagem atualizado = service.atualizar(idPersonagem, personagemTaijutsu);
+
+        assertNotNull(atualizado);
+        assertEquals("Rock Lee", atualizado.getNome());
+        assertEquals(idadePersonagem, atualizado.getIdade());
+        verify(repository).findById(idPersonagem);
+        verify(repository).save(personagemTaijutsu);
+    }
+    
+    @Test
+    @DisplayName("Deve lançar exceção ao tentar atualizar personagem com chakra negativo")
+    void deveLancarExcecaoAoTentarAtualizarPersonagemComChakraNegativo() {
+        Long idPersonagem = 1L;
+        int chakraNegativo = -50;
+        personagemTaijutsu.setChakra(chakraNegativo);
+        
+        when(repository.findById(idPersonagem)).thenReturn(Optional.of(new NinjaDeTaijutsu()));
+        
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.atualizar(idPersonagem, personagemTaijutsu);
+        });
+        
+        assertEquals("Chakra nao pode ser negativo", exception.getMessage());
+        verify(repository).findById(idPersonagem);
+        verify(repository, never()).save(any(Personagem.class));
+    }
+
+    @Test
+    @DisplayName("Deve criar personagem do tipo Taijutsu")
+    void deveCriarPersonagemDoTipoTaijutsu() {
+        PersonagemDTO dto = new PersonagemDTO();
+        dto.setTipoNinja("TAIJUTSU");
+        dto.setNome("Rock Lee");
+        dto.setIdade(16);
+        dto.setAldeia("Aldeia da Folha");
+        dto.setChakra(100);
+        dto.setJutsus(Arrays.asList("Dynamic Entry", "Leaf Hurricane"));
+
+        NinjaDeTaijutsu novoPersonagem = new NinjaDeTaijutsu();
+        novoPersonagem.setId(1L);
+        novoPersonagem.setNome(dto.getNome());
+        novoPersonagem.setIdade(dto.getIdade());
+        novoPersonagem.setAldeia(dto.getAldeia());
+        novoPersonagem.setChakra(dto.getChakra());
+        novoPersonagem.setJutsus(dto.getJutsus());
+
+        when(repository.save(any(NinjaDeTaijutsu.class))).thenReturn(novoPersonagem);
+
+        Personagem resultado = service.criarPersonagem(dto);
+
+        assertNotNull(resultado);
+        assertTrue(resultado instanceof NinjaDeTaijutsu);
+        assertEquals(dto.getNome(), resultado.getNome());
+        assertEquals(dto.getIdade(), resultado.getIdade());
+        assertEquals(dto.getAldeia(), resultado.getAldeia());
+        assertEquals(dto.getChakra(), resultado.getChakra());
+        assertEquals(dto.getJutsus(), resultado.getJutsus());
+        verify(repository).save(any(NinjaDeTaijutsu.class));
+    }
+    
+    @Test
+    @DisplayName("Deve criar personagem do tipo Ninjutsu")
+    void deveCriarPersonagemDoTipoNinjutsu() {
+
+        PersonagemDTO dto = new PersonagemDTO();
+        dto.setTipoNinja("NINJUTSU");
+        dto.setNome("Naruto Uzumaki");
+        dto.setIdade(17);
+        dto.setAldeia("Aldeia da Folha");
+        dto.setChakra(500);
+        dto.setJutsus(Arrays.asList("Rasengan", "Kage Bunshin no Jutsu"));
+
+        NinjaDeNinjutsu novoPersonagem = new NinjaDeNinjutsu();
+        novoPersonagem.setId(2L);
+        novoPersonagem.setNome(dto.getNome());
+        novoPersonagem.setIdade(dto.getIdade());
+        novoPersonagem.setAldeia(dto.getAldeia());
+        novoPersonagem.setChakra(dto.getChakra());
+        novoPersonagem.setJutsus(dto.getJutsus());
+
+        when(repository.save(any(NinjaDeNinjutsu.class))).thenReturn(novoPersonagem);
+
+        Personagem resultado = service.criarPersonagem(dto);
+
+        assertNotNull(resultado);
+        assertTrue(resultado instanceof NinjaDeNinjutsu);
+        assertEquals(dto.getNome(), resultado.getNome());
+        assertEquals(dto.getIdade(), resultado.getIdade());
+        assertEquals(dto.getAldeia(), resultado.getAldeia());
+        assertEquals(dto.getChakra(), resultado.getChakra());
+        assertEquals(dto.getJutsus(), resultado.getJutsus());
+        verify(repository).save(any(NinjaDeNinjutsu.class));
+    }
+    
+    @Test
+    @DisplayName("Deve criar personagem do tipo Genjutsu")
+    void deveCriarPersonagemDoTipoGenjutsu() {
+
+        PersonagemDTO dto = new PersonagemDTO();
+        dto.setTipoNinja("GENJUTSU");
+        dto.setNome("Itachi Uchiha");
+        dto.setIdade(21);
+        dto.setAldeia("Aldeia da Folha");
+        dto.setChakra(300);
+        dto.setJutsus(Arrays.asList("Tsukuyomi", "Amaterasu"));
+
+        NinjaDeGenjutsu novoPersonagem = new NinjaDeGenjutsu();
+        novoPersonagem.setId(3L);
+        novoPersonagem.setNome(dto.getNome());
+        novoPersonagem.setIdade(dto.getIdade());
+        novoPersonagem.setAldeia(dto.getAldeia());
+        novoPersonagem.setChakra(dto.getChakra());
+        novoPersonagem.setJutsus(dto.getJutsus());
+
+        when(repository.save(any(NinjaDeGenjutsu.class))).thenReturn(novoPersonagem);
+
+        Personagem resultado = service.criarPersonagem(dto);
+
+        assertNotNull(resultado);
+        assertTrue(resultado instanceof NinjaDeGenjutsu);
+        assertEquals(dto.getNome(), resultado.getNome());
+        assertEquals(dto.getIdade(), resultado.getIdade());
+        assertEquals(dto.getAldeia(), resultado.getAldeia());
+        assertEquals(dto.getChakra(), resultado.getChakra());
+        assertEquals(dto.getJutsus(), resultado.getJutsus());
+        verify(repository).save(any(NinjaDeGenjutsu.class));
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção ao tentar criar personagem com tipo ninja inválido")
+    void deveLancarExcecaoAoTentarCriarPersonagemComTipoNinjaInvalido() {
+        PersonagemDTO dto = new PersonagemDTO();
+        dto.setTipoNinja("INVALID");
+        dto.setNome("Invalid Ninja");
+        dto.setIdade(20);
+        dto.setAldeia("Aldeia da Folha");
+        dto.setChakra(100);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.criarPersonagem(dto);
+        });
+        
+        assertEquals("Tipo de ninja inválido", exception.getMessage());
+        verify(repository, never()).save(any(Personagem.class));
+    }
+
+    
+
+    @Test
+    @DisplayName("Deve usar jutsu de Taijutsu com sucesso")
+    void deveUsarJutsuDeTaijutsuComSucesso() {
+        Long idDePersonagem = 1L;
+        when(repository.findById(idDePersonagem)).thenReturn(Optional.of(personagemTaijutsu));
+
+        Map<String, Object> resultado = service.usarJutsu(idDePersonagem);
+
+        assertNotNull(resultado);
+        assertEquals(personagemTaijutsu.getNome(), resultado.get("nome"));
+        assertEquals("Taijutsu", resultado.get("tipoNinja"));
+        assertEquals(personagemTaijutsu.getNome() + " está usando um golpe de Taijutsu!", resultado.get("mensagem"));
+        verify(repository).findById(1L);
+    }
+
+    @Test
+    @DisplayName("Deve usar jutsu de Ninjutsu com sucesso")
+    void deveUsarJutsuDeNinjutsuComSucesso() {
+        Long idDePersonagem = 2L;
+        when(repository.findById(idDePersonagem)).thenReturn(Optional.of(personagemNinjutsu));
+
+        Map<String, Object> resultado = service.usarJutsu(idDePersonagem);
+
+        assertNotNull(resultado);
+        assertEquals(personagemNinjutsu.getNome(), resultado.get("nome"));
+        assertEquals("Ninjutsu", resultado.get("tipoNinja"));
+        assertEquals(personagemNinjutsu.getNome() + " está usando um jutsu de Ninjutsu!", resultado.get("mensagem"));
+        verify(repository).findById(idDePersonagem);
+    }
+
+    @Test
+    @DisplayName("Deve usar jutsu de Genjutsu com sucesso")
+    void deveUsarJutsuDeGenjutsuComSucesso() {
+        Long idDePersonagem = 3L;
+        when(repository.findById(idDePersonagem)).thenReturn(Optional.of(personagemGenjutsu));
+
+        Map<String, Object> resultado = service.usarJutsu(idDePersonagem);
+
+        assertNotNull(resultado);
+        assertEquals(personagemGenjutsu.getNome(), resultado.get("nome"));
+        assertEquals("Genjutsu", resultado.get("tipoNinja"));
+        assertEquals(personagemGenjutsu.getNome() + " está usando um jutsu de Genjutsu!", resultado.get("mensagem"));
+        verify(repository).findById(idDePersonagem);
+    }
+    
+    @Test
+    @DisplayName("Deve lançar exceção ao tentar usar jutsu com personagem não ninja")
+    void deveLancarExcecaoAoTentarUsarJutsuComPersonagemNaoNinja() {
+        Long idPersonagem = 99L;
+        Personagem personagemGenerico = mock(Personagem.class);
+        when(personagemGenerico.getNome()).thenReturn("Personagem Genérico");
+        
+        when(repository.findById(idPersonagem)).thenReturn(Optional.of(personagemGenerico));
+        
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.usarJutsu(idPersonagem);
+        });
+        
+        assertEquals("Personagem não é um ninja.", exception.getMessage());
+        verify(repository).findById(idPersonagem);
+    }
+
+    @Test
+    @DisplayName("Deve desviar com Taijutsu com sucesso")
+    void deveDesviarComTaijutsuComSucesso() {
+        Long idPersonagem = 1L;
+        when(repository.findById(idPersonagem)).thenReturn(Optional.of(personagemTaijutsu));
+
+        Map<String, Object> resultado = service.desviar(idPersonagem);
+
+        assertNotNull(resultado);
+        assertEquals(personagemTaijutsu.getNome(), resultado.get("nome"));
+        assertEquals("Taijutsu", resultado.get("tipoNinja"));
+        assertEquals(personagemTaijutsu.getNome() + " está desviando usando suas habilidades de Taijutsu!", resultado.get("mensagem"));
+        verify(repository).findById(idPersonagem);
+    }
+    
+    @Test
+    @DisplayName("Deve desviar com Ninjutsu com sucesso")
+    void deveDesviarComNinjutsuComSucesso() {
+        Long idPersonagem = 2L;
+        when(repository.findById(idPersonagem)).thenReturn(Optional.of(personagemNinjutsu));
+
+        Map<String, Object> resultado = service.desviar(idPersonagem);
+
+        assertNotNull(resultado);
+        assertEquals(personagemNinjutsu.getNome(), resultado.get("nome"));
+        assertEquals("Ninjutsu", resultado.get("tipoNinja"));
+        assertEquals(personagemNinjutsu.getNome() + " está desviando usando suas habilidades de Ninjutsu!", resultado.get("mensagem"));
+        verify(repository).findById(idPersonagem);
+    }
+    
+    @Test
+    @DisplayName("Deve desviar com Genjutsu com sucesso")
+    void deveDesviarComGenjutsuComSucesso() {
+        Long idPersonagem = 3L;
+        when(repository.findById(idPersonagem)).thenReturn(Optional.of(personagemGenjutsu));
+
+        Map<String, Object> resultado = service.desviar(idPersonagem);
+
+        assertNotNull(resultado);
+        assertEquals(personagemGenjutsu.getNome(), resultado.get("nome"));
+        assertEquals("Genjutsu", resultado.get("tipoNinja"));
+        assertEquals(personagemGenjutsu.getNome() + " está desviando usando suas habilidades de Genjutsu!", resultado.get("mensagem"));
+        verify(repository).findById(idPersonagem);
+    }
+    
+    @Test
+    @DisplayName("Deve lançar exceção ao tentar desviar com personagem não ninja")
+    void deveLancarExcecaoAoTentarDesviarComPersonagemNaoNinja() {
+        Long idPersonagem = 99L;
+        Personagem personagemGenerico = mock(Personagem.class);
+        when(personagemGenerico.getNome()).thenReturn("Personagem Genérico");
+        
+        when(repository.findById(idPersonagem)).thenReturn(Optional.of(personagemGenerico));
+        
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.desviar(idPersonagem);
+        });
+        
+        assertEquals("Personagem não é um ninja.", exception.getMessage());
+        verify(repository).findById(idPersonagem);
+    }
+}

--- a/src/test/java/com/sylviavitoria/naruto/controller/PersonagemControllerTest.java
+++ b/src/test/java/com/sylviavitoria/naruto/controller/PersonagemControllerTest.java
@@ -1,0 +1,256 @@
+package com.sylviavitoria.naruto.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sylviavitoria.naruto.dto.PersonagemAtualizarDTO;
+import com.sylviavitoria.naruto.dto.PersonagemDTO;
+import com.sylviavitoria.naruto.model.NinjaDeNinjutsu;
+import com.sylviavitoria.naruto.model.Personagem;
+import com.sylviavitoria.naruto.security.JwtAuthenticationFilter;
+import com.sylviavitoria.naruto.security.JwtService;
+import com.sylviavitoria.naruto.service.PersonagemService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = PersonagemController.class, excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+})
+public class PersonagemControllerTest {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @MockBean
+        private PersonagemService personagemService;
+
+        @MockBean
+        private JwtService jwtService;
+
+        @MockBean
+        private UserDetailsService userDetailsService;
+
+        @Autowired
+        private ObjectMapper objectMapper;
+
+        private Personagem personagem;
+        private PersonagemDTO personagemDTO;
+        private PersonagemAtualizarDTO personagemAtualizarDTO;
+
+        @BeforeEach
+        void setUp() {
+                personagem = new NinjaDeNinjutsu();
+                personagem.setId(1L);
+                personagem.setNome("Naruto Uzumaki");
+                personagem.setIdade(17);
+                personagem.setAldeia("Aldeia da Folha");
+                personagem.setChakra(100);
+                personagem.setJutsus(Arrays.asList("Rasengan", "Kage Bunshin no Jutsu"));
+
+                personagemDTO = new PersonagemDTO();
+                personagemDTO.setTipoNinja("NINJUTSU");
+                personagemDTO.setNome("Sasuke Uchiha");
+                personagemDTO.setIdade(17);
+                personagemDTO.setAldeia("Aldeia da Folha");
+                personagemDTO.setChakra(90);
+                personagemDTO.setJutsus(Arrays.asList("Chidori", "Sharingan"));
+
+                personagemAtualizarDTO = new PersonagemAtualizarDTO();
+                personagemAtualizarDTO.setNome("Naruto Uzumaki (Modo Sábio)");
+                personagemAtualizarDTO.setChakra(150);
+        }
+
+        @Test
+        @WithMockUser
+        void buscarPorId_QuandoPersonagemExiste_DeveRetornarPersonagem() throws Exception {
+                when(personagemService.buscarPorId(1L)).thenReturn(personagem);
+
+                mockMvc.perform(get("/api/v1/personagens/1")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.id").value(1))
+                                .andExpect(jsonPath("$.nome").value("Naruto Uzumaki"))
+                                .andExpect(jsonPath("$.idade").value(17))
+                                .andExpect(jsonPath("$.aldeia").value("Aldeia da Folha"))
+                                .andExpect(jsonPath("$.chakra").value(100))
+                                .andExpect(jsonPath("$.jutsus[0]").value("Rasengan"))
+                                .andExpect(jsonPath("$.jutsus[1]").value("Kage Bunshin no Jutsu"));
+        }
+
+        @Test
+        @WithMockUser
+        void buscarPorId_QuandoPersonagemNaoExiste_DeveRetornarStatus404() throws Exception {
+                when(personagemService.buscarPorId(anyLong()))
+                                .thenThrow(new RuntimeException("Personagem nao encontrado"));
+
+                mockMvc.perform(get("/api/v1/personagens/999")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isInternalServerError());
+        }
+
+        @Test
+        @WithMockUser
+        void buscarPorId_QuandoIdInvalido_DeveRetornarStatus500() throws Exception {
+                mockMvc.perform(get("/api/v1/personagens/abc")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isInternalServerError());
+        }
+
+        @Test
+        @WithMockUser
+        void listarTodos_DeveRetornarPersonagensPaginados() throws Exception {
+                List<Personagem> personagens = Arrays.asList(personagem);
+                Page<Personagem> paginaPersonagens = new PageImpl<>(personagens);
+                when(personagemService.listarTodos(any(Pageable.class))).thenReturn(paginaPersonagens);
+
+                mockMvc.perform(get("/api/v1/personagens")
+                                .param("page", "0")
+                                .param("size", "10")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.content[0].id").value(1))
+                                .andExpect(jsonPath("$.content[0].nome").value("Naruto Uzumaki"))
+                                .andExpect(jsonPath("$.totalElements").value(1));
+        }
+
+        @Test
+        @WithMockUser
+        void listarTodos_ComParametroDeOrdenacao_DeveRetornarPersonagensPaginados() throws Exception {
+                List<Personagem> personagens = Arrays.asList(personagem);
+                Page<Personagem> paginaPersonagens = new PageImpl<>(personagens);
+                when(personagemService.listarTodos(any(Pageable.class))).thenReturn(paginaPersonagens);
+
+                mockMvc.perform(get("/api/v1/personagens")
+                                .param("page", "0")
+                                .param("size", "10")
+                                .param("sort", "nome")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.content[0].id").value(1))
+                                .andExpect(jsonPath("$.content[0].nome").value("Naruto Uzumaki"));
+        }
+
+        @Test
+        @WithMockUser
+        void usarJutsu_QuandoPersonagemExiste_DeveRetornarMensagemJutsu() throws Exception {
+                Map<String, Object> resultado = new HashMap<>();
+                resultado.put("nome", "Naruto Uzumaki");
+                resultado.put("tipoNinja", "Ninjutsu");
+                resultado.put("mensagem", "Naruto Uzumaki está usando um jutsu de Ninjutsu!");
+
+                when(personagemService.usarJutsu(anyLong())).thenReturn(resultado);
+
+                mockMvc.perform(get("/api/v1/personagens/1/usar-jutsu")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.nome").value("Naruto Uzumaki"))
+                                .andExpect(jsonPath("$.tipoNinja").value("Ninjutsu"))
+                                .andExpect(jsonPath("$.mensagem")
+                                                .value("Naruto Uzumaki está usando um jutsu de Ninjutsu!"));
+
+                verify(personagemService, times(1)).usarJutsu(1L);
+        }
+
+        @Test
+        @WithMockUser
+        void usarJutsu_QuandoPersonagemNaoExiste_DeveRetornarStatus404() throws Exception {
+                when(personagemService.usarJutsu(anyLong()))
+                                .thenThrow(new RuntimeException("Personagem nao encontrado"));
+
+                mockMvc.perform(get("/api/v1/personagens/999/usar-jutsu")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isInternalServerError());
+
+                verify(personagemService, times(1)).usarJutsu(999L);
+        }
+
+        @Test
+        @WithMockUser
+        void usarJutsu_QuandoPersonagemNaoENinja_DeveRetornarStatus400() throws Exception {
+                when(personagemService.usarJutsu(anyLong()))
+                                .thenThrow(new IllegalArgumentException("Personagem não é um ninja."));
+
+                mockMvc.perform(get("/api/v1/personagens/1/usar-jutsu")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isBadRequest()); 
+
+                verify(personagemService, times(1)).usarJutsu(1L);
+        }
+
+        @Test
+        @WithMockUser
+        void desviar_QuandoPersonagemNaoENinja_DeveRetornarStatus400() throws Exception {
+                when(personagemService.desviar(anyLong()))
+                                .thenThrow(new IllegalArgumentException("Personagem não é um ninja."));
+
+                mockMvc.perform(get("/api/v1/personagens/1/desviar")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isBadRequest()); 
+
+                verify(personagemService, times(1)).desviar(1L);
+        }
+
+        @Test
+        @WithMockUser
+        void desviar_QuandoPersonagemExiste_DeveRetornarMensagemDesvio() throws Exception {
+                Map<String, Object> resultado = new HashMap<>();
+                resultado.put("nome", "Naruto Uzumaki");
+                resultado.put("tipoNinja", "Ninjutsu");
+                resultado.put("mensagem", "Naruto Uzumaki está desviando usando suas habilidades de Ninjutsu!");
+
+                when(personagemService.desviar(anyLong())).thenReturn(resultado);
+
+                mockMvc.perform(get("/api/v1/personagens/1/desviar")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.nome").value("Naruto Uzumaki"))
+                                .andExpect(jsonPath("$.tipoNinja").value("Ninjutsu"))
+                                .andExpect(jsonPath("$.mensagem")
+                                                .value("Naruto Uzumaki está desviando usando suas habilidades de Ninjutsu!"));
+
+                verify(personagemService, times(1)).desviar(1L);
+        }
+
+        @Test
+        @WithMockUser
+        void desviar_QuandoPersonagemNaoExiste_DeveRetornarStatus404() throws Exception {
+                when(personagemService.desviar(anyLong()))
+                                .thenThrow(new RuntimeException("Personagem nao encontrado"));
+
+                mockMvc.perform(get("/api/v1/personagens/999/desviar")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isInternalServerError());
+
+                verify(personagemService, times(1)).desviar(999L);
+        }
+
+}

--- a/src/test/java/com/sylviavitoria/naruto/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/sylviavitoria/naruto/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,59 @@
+package com.sylviavitoria.naruto.exception;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GlobalExceptionHandlerTest {
+    
+    private GlobalExceptionHandler exceptionHandler;
+    
+    @BeforeEach
+    void setUp() {
+        exceptionHandler = new GlobalExceptionHandler();
+    }
+    
+    @Test
+    void handleIllegalArgumentException_deveRetornarStatusBadRequest() {
+        String mensagemErro = "Parâmetro inválido";
+        IllegalArgumentException exception = new IllegalArgumentException(mensagemErro);
+        
+        ResponseEntity<Object> response = exceptionHandler.handleIllegalArgumentException(exception);
+        
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), body.get("status"));
+        assertEquals("Requisição inválida", body.get("error"));
+        assertEquals(mensagemErro, body.get("message"));
+        assertNotNull(body.get("timestamp"));
+        assertTrue(body.get("timestamp") instanceof LocalDateTime);
+    }
+    
+    @Test
+    void handleRuntimeException_deveRetornarStatusInternalServerError() {
+        String mensagemErro = "Erro interno do servidor";
+        RuntimeException exception = new RuntimeException(mensagemErro);
+        
+        ResponseEntity<Object> response = exceptionHandler.handleRuntimeException(exception);
+        
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), body.get("status"));
+        assertEquals("Erro interno", body.get("error"));
+        assertEquals(mensagemErro, body.get("message"));
+        assertNotNull(body.get("timestamp"));
+        assertTrue(body.get("timestamp") instanceof LocalDateTime);
+    }
+}

--- a/src/test/java/com/sylviavitoria/naruto/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/sylviavitoria/naruto/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,150 @@
+package com.sylviavitoria.naruto.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import java.io.IOException;
+import java.util.ArrayList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    private UserDetails userDetails;
+    private static final String TOKEN_VALIDO = "TokenValido";
+    private static final String TOKEN_INVALIDO = "TokenInvalido";
+    private static final String USERNAME = "ninja_test";
+
+    @BeforeEach
+    void setUp() {
+    
+        SecurityContextHolder.setContext(securityContext);
+
+        userDetails = new User(USERNAME, "password", new ArrayList<>());
+    }
+
+    @Test
+    @DisplayName("Não deve autenticar quando o header Authorization estiver ausente")
+    void devePassarADianteQuandoHeaderAuthorizationEstiverAusente() throws ServletException, IOException {
+        when(request.getHeader("Authorization")).thenReturn(null);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        verify(jwtService, never()).extractUsername(anyString());
+        verify(userDetailsService, never()).loadUserByUsername(anyString());
+    }
+
+    @Test
+    @DisplayName("Não deve autenticar quando o Authorization não começar com Bearer")
+    void devePassarADianteQuandoAuthorizationNaoComecaComBearer() throws ServletException, IOException {
+        when(request.getHeader("Authorization")).thenReturn("Token " + TOKEN_VALIDO);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        verify(jwtService, never()).extractUsername(anyString());
+        verify(userDetailsService, never()).loadUserByUsername(anyString());
+    }
+
+    @Test
+    @DisplayName("Deve extrair username do token e carregar UserDetails quando token for válido")
+    void deveExtrairUsernameECarregarUserDetailsQuandoTokenForValido() throws ServletException, IOException {
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + TOKEN_VALIDO);
+        when(jwtService.extractUsername(TOKEN_VALIDO)).thenReturn(USERNAME);
+        when(securityContext.getAuthentication()).thenReturn(null);
+        when(userDetailsService.loadUserByUsername(USERNAME)).thenReturn(userDetails);
+        when(jwtService.isTokenValid(TOKEN_VALIDO, userDetails)).thenReturn(true);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(jwtService, times(1)).extractUsername(TOKEN_VALIDO);
+        verify(userDetailsService, times(1)).loadUserByUsername(USERNAME);
+        verify(jwtService, times(1)).isTokenValid(TOKEN_VALIDO, userDetails);
+        verify(securityContext, times(1)).setAuthentication(any(UsernamePasswordAuthenticationToken.class));
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Não deve configurar autenticação quando token for inválido")
+    void naoDeveConfigurarAutenticacaoQuandoTokenForInvalido() throws ServletException, IOException {
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + TOKEN_INVALIDO);
+        when(jwtService.extractUsername(TOKEN_INVALIDO)).thenReturn(USERNAME);
+        when(securityContext.getAuthentication()).thenReturn(null);
+        when(userDetailsService.loadUserByUsername(USERNAME)).thenReturn(userDetails);
+        when(jwtService.isTokenValid(TOKEN_INVALIDO, userDetails)).thenReturn(false);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(jwtService, times(1)).extractUsername(TOKEN_INVALIDO);
+        verify(userDetailsService, times(1)).loadUserByUsername(USERNAME);
+        verify(jwtService, times(1)).isTokenValid(TOKEN_INVALIDO, userDetails);
+        verify(securityContext, never()).setAuthentication(any(UsernamePasswordAuthenticationToken.class));
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Não deve carregar UserDetails quando username do token for nulo")
+    void naoDeveCarregarUserDetailsQuandoUsernameForNulo() throws ServletException, IOException {
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + TOKEN_INVALIDO);
+        when(jwtService.extractUsername(TOKEN_INVALIDO)).thenReturn(null);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(jwtService, times(1)).extractUsername(TOKEN_INVALIDO);
+        verify(userDetailsService, never()).loadUserByUsername(anyString());
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Não deve configurar autenticação quando o contexto já possui autenticação")
+    void naoDeveConfigurarAutenticacaoQuandoContextoJaPossuiAutenticacao() throws ServletException, IOException {
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + TOKEN_VALIDO);
+        when(jwtService.extractUsername(TOKEN_VALIDO)).thenReturn(USERNAME);
+        when(securityContext.getAuthentication()).thenReturn(mock(UsernamePasswordAuthenticationToken.class));
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(jwtService, times(1)).extractUsername(TOKEN_VALIDO);
+        verify(userDetailsService, never()).loadUserByUsername(anyString());
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+}

--- a/src/test/java/com/sylviavitoria/naruto/security/JwtServiceTest.java
+++ b/src/test/java/com/sylviavitoria/naruto/security/JwtServiceTest.java
@@ -1,0 +1,108 @@
+package com.sylviavitoria.naruto.security;
+
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtServiceTest {
+
+    private JwtService jwtService;
+    private UserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtService();
+
+        ReflectionTestUtils.setField(jwtService, "secretKey",
+                "404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970");
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", 86400000L);
+
+        userDetails = new User("ninja_test", "password123", new ArrayList<>());
+    }
+
+    @Test
+    @DisplayName("Deve extrair username do token")
+    void deveExtrairUsernameDoToken() {
+        String token = jwtService.generateToken(userDetails);
+
+        String username = jwtService.extractUsername(token);
+
+        assertEquals("ninja_test", username);
+    }
+
+    @Test
+    @DisplayName("Deve extrair data de expiração do token")
+    void deveExtrairDataDeExpiracaoDoToken() {
+        String token = jwtService.generateToken(userDetails);
+
+        Date expiration = jwtService.extractClaim(token, Claims::getExpiration);
+
+        assertNotNull(expiration);
+        assertTrue(expiration.after(new Date()));
+    }
+
+    @Test
+    @DisplayName("Deve gerar token com claims extras")
+    void deveGerarTokenComClaimsExtras() {
+        Map<String, Object> extraClaims = new HashMap<>();
+        extraClaims.put("aldeia", "Folha");
+        extraClaims.put("rank", "Jounin");
+
+        String token = jwtService.generateToken(extraClaims, userDetails);
+
+        assertEquals("Folha", jwtService.extractClaim(token, claims -> claims.get("aldeia")));
+        assertEquals("Jounin", jwtService.extractClaim(token, claims -> claims.get("rank")));
+    }
+
+    @Test
+    @DisplayName("Deve validar token válido")
+    void deveValidarTokenValido() {
+        String token = jwtService.generateToken(userDetails);
+
+        assertTrue(jwtService.isTokenValid(token, userDetails));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar token para usuário diferente")
+    void deveRejeitarTokenParaUsuarioDiferente() {
+        String token = jwtService.generateToken(userDetails);
+        UserDetails outroUsuario = new User("sasuke", "password123", new ArrayList<>());
+
+        assertFalse(jwtService.isTokenValid(token, outroUsuario));
+    }
+
+    @Test
+    @DisplayName("Deve gerar tokens diferentes para o mesmo usuário")
+    void deveGerarTokensDiferentesParaMesmoUsuario() throws Exception {
+        String token1 = jwtService.generateToken(userDetails);
+
+        Thread.sleep(1100); 
+
+        String token2 = jwtService.generateToken(userDetails);
+
+        assertNotEquals(token1, token2);
+    }
+
+    @Test
+    @DisplayName("Deve extrair todas as claims do token")
+    void deveExtrairTodasClaimsDoToken() {
+        Map<String, Object> extraClaims = new HashMap<>();
+        extraClaims.put("ninjutsu", "Rasengan");
+        String token = jwtService.generateToken(extraClaims, userDetails);
+
+        Object ninjutsu = jwtService.extractClaim(token, claims -> claims.get("ninjutsu"));
+
+        assertEquals("Rasengan", ninjutsu);
+    }
+}


### PR DESCRIPTION
# 📍 Test(crud-naruto)

## 📌 Descrição
Este pull request introduz melhorias na estrutura de testes, atualizações de dependências e pequenas alterações de configuração. As mudanças mais significativas incluem a adição de testes unitários abrangentes para `PersonagemController`, `GlobalExceptionHandler` e `JwtAuthenticationFilter`, bem como a inclusão de uma nova dependência de teste no arquivo `pom.xml`.

### Melhorias nos Testes:

* **`PersonagemControllerTest`**: Testes unitários abrangentes adicionados para `PersonagemController` para validar endpoints como busca, listagem e execução de ações (`usarJutsu`, `desviar`) em personagens. Esses testes incluem cenários para respostas válidas, tratamento de erros e casos extremos.
* **`GlobalExceptionHandlerTest`**: Testes introduzidos para `GlobalExceptionHandler` para verificar o tratamento adequado de `IllegalArgumentException` e `RuntimeException`, garantindo códigos de status HTTP e estruturas de resposta corretos.

* **`JwtAuthenticationFilterTest`**: Testes unitários adicionados para o `JwtAuthenticationFilter` para cobrir cenários como tokens ausentes/inválidos, autenticação de token válido e autenticação preexistente no contexto de segurança.

### Atualizações de Dependências:

* **`pom.xml`**: A dependência `spring-security-test` foi adicionada para facilitar os testes relacionados à segurança. Essa dependência tem como escopo `test` para evitar impactos nas compilações de produção.

### Alterações na Configuração:

* **`application.properties`**: Credenciais padrão adicionadas (`spring.security.user.name` e `spring.security.user.password`) para fins de teste, juntamente com as propriedades de configuração JWT existentes.

### Pequena Limpeza:

* **`OpenApiConfig.java`**: Uma importação não utilizada para `License` foi removida para melhorar a clareza do código.

